### PR TITLE
Upgrade to opentelemetry 0.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [**breaking**] bump opentelemetry to 0.28.0
+
 ## [3.0.0](https://github.com/open-schnick/DatadogFormattingLayer/compare/v2.2.1...v3.0.0) - 2024-09-03
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,12 @@ serde_json = { version = "1", features = ["preserve_order"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 # otel
-tracing-opentelemetry = { version = "0.24", default-features = false }
-opentelemetry = { version = "0.23", default-features = false }
+tracing-opentelemetry = { version = "0.29", default-features = false }
+opentelemetry = { version = "0.28", default-features = false }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-opentelemetry-datadog = { version = "0.11", features = ["reqwest-client"] }
-opentelemetry_sdk = { version = "0.23", features = ["rt-tokio"] }
+opentelemetry-datadog = { version = "0.16", features = ["reqwest-blocking-client"] }
+opentelemetry_sdk = { version = "0.28", features = ["rt-tokio"] }
 regex = "1.10"
 smoothy = "0.5"
 
@@ -99,4 +98,3 @@ redundant_pub_crate = "deny"
 # allow some lints
 module_name_repetitions = "allow"
 tests_outside_test_module = "allow"
-

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -176,6 +176,7 @@ mod format {
         assert_that(sut.format()).is(json!({"timestamp": "2022-01-01T00:00:00+00:00", "level": "INFO", "fields.a": "c", "fields.b": "b", "fields.c": "a", "message": "Hello World! a=c b=b c=a", "target": "target"}).to_string());
     }
 
+    #[allow(missing_docs)]
     #[macro_export]
     macro_rules! timestamp {
         ($date:expr) => {

--- a/tests/custom_sink.rs
+++ b/tests/custom_sink.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use datadog_formatting_layer::{DatadogFormattingLayer, StdoutSink};
 use tracing::warn;
 use tracing_subscriber::prelude::*;

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use datadog_formatting_layer::DatadogFormattingLayer;
 use tracing::{debug, error, info, instrument, warn};
 use tracing_subscriber::prelude::*;


### PR DESCRIPTION
This is required to upgrade to make log correlation continue to work, as otherwise the `OTelData` struct will be referencing the wrong crate version, causing span extension extraction to fail. I've confirmed this works with our service that is on the latest versions of opentelemetry & tracing.

It's somewhat chunky because opentelemetry dropped the requirement for an async runtime, which means reporting is done through the reqwest blocking client. Due to some peculiarities of how that works, the opentelemetry instrumentation cannot be setup in an async context anymore, lest one gets "cannot drop runtime" errors.

I've also adjusted the test cases and documentation to the new APIs, and made sure all tests pass in the current form.

There are still some deprecation warnings in the otel example concerning the trace config builder, but I deemed those non-essential for the time being.