### PR TITLE
Upgrade to opentelemetry 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ serde_json = { version = "1", features = ["preserve_order"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 # otel
-tracing-opentelemetry = { version = "0.29", default-features = false }
-opentelemetry = { version = "0.28", default-features = false }
+tracing-opentelemetry = { version = "0.30", default-features = false }
+opentelemetry = { version = "0.29", default-features = false }
 
 [dev-dependencies]
-opentelemetry-datadog = { version = "0.16", features = ["reqwest-blocking-client"] }
-opentelemetry_sdk = "0.28"
+opentelemetry-datadog = { version = "0.17", features = ["reqwest-blocking-client"] }
+opentelemetry_sdk = "0.29"
 smoothy = "0.7"
 
 [lints.rust]

--- a/README.md
+++ b/README.md
@@ -58,14 +58,10 @@ use tracing::{dispatcher::DefaultGuard, info, Level, instrument};
 use tracing_subscriber::{filter::Targets, prelude::*};
 
 fn main() {
-    // IMPORTANT: as of otel version 0.28 this has to be called outside the context of an async runtime
+    // IMPORTANT: as of otel version 0.28+ this has to be called outside the context of an async runtime
     let provider = opentelemetry_datadog::new_pipeline()
         .with_service_name("my-service")
-        .with_trace_config(
-            Config::default()
-                .with_sampler(Sampler::AlwaysOn)
-                .with_id_generator(RandomIdGenerator::default()),
-        )
+        .with_trace_config(Config::default())
         .with_api_version(ApiVersion::Version05)
         .with_env("rls")
         .with_version("420")
@@ -123,6 +119,7 @@ Otherwise, the following output will be printed to stdout (fields are excluded f
 
 | OpenTelemetry | DatadogFormattingLayer |
 | ------------- | ---------------------- |
+| 0.29.\*       | 5.\*                   |
 | 0.28.\*       | 4.\*                   |
 | 0.23.\*       | 3.\*                   |
 | 0.22.\*       | 2.1.\*, 2.2.\*         |

--- a/tests/layer/otel.rs
+++ b/tests/layer/otel.rs
@@ -2,7 +2,7 @@ use crate::ObservableSink;
 use datadog_formatting_layer::DatadogFormattingLayer;
 use opentelemetry::{global, trace::TracerProvider};
 use opentelemetry_datadog::ApiVersion;
-use opentelemetry_sdk::trace::{Config, RandomIdGenerator, Sampler};
+use opentelemetry_sdk::trace::Config;
 use serde_json::Value;
 use smoothy::prelude::*;
 use tracing::{debug, dispatcher::DefaultGuard, error, info, instrument, span, warn, Level};
@@ -93,14 +93,9 @@ fn events_created_by_instrument_macro_are_correctly_printed() {
 fn setup_otel_subscriber() -> (ObservableSink, DefaultGuard) {
     let sink = ObservableSink::default();
 
-    #[allow(deprecated)]
     let provider = opentelemetry_datadog::new_pipeline()
         .with_service_name("my-service")
-        .with_trace_config(
-            Config::default()
-                .with_sampler(Sampler::AlwaysOn)
-                .with_id_generator(RandomIdGenerator::default()),
-        )
+        .with_trace_config(Config::default())
         .with_api_version(ApiVersion::Version05)
         .with_env("rls")
         .with_version("420")


### PR DESCRIPTION
This is fairly simple, some methods on `opentelemetry_sdk::trace::Config` have gone away, but the default values match what we were setting before, so no functional change.