### PR TITLE
build(deps)!: Upgrade to opentelemetry 0.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/open-schnick/DatadogFormattingLayer"
 license = "Apache-2.0"
 keywords = ["tracing", "tracing-subscriber", "layer", "datadog"]
 categories = ["development-tools::debugging"]
-version = "7.0.0"
+version = "8.0.0"
 edition = "2021"
 
 [dependencies]
@@ -20,12 +20,12 @@ serde_json = { version = "1", features = ["preserve_order"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 # otel
-tracing-opentelemetry = { version = "0.32", default-features = false }
-opentelemetry = { version = "0.31", default-features = false }
+tracing-opentelemetry = { version = "0.33", default-features = false }
+opentelemetry = { version = "0.32", default-features = false }
 
 [dev-dependencies]
-opentelemetry-datadog = { version = "0.19", features = ["reqwest-blocking-client"] }
-opentelemetry_sdk = "0.31"
+opentelemetry-datadog = { version = "0.20", features = ["reqwest-blocking-client"] }
+opentelemetry_sdk = "0.32"
 smoothy = "0.8"
 
 [lints.rust]

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Otherwise, the following output will be printed to stdout (fields are excluded f
 
 | OpenTelemetry | DatadogFormattingLayer |
 | ------------- | ---------------------- |
+| 0.32.\*       | 8.\*                   |
 | 0.31.\*       | 7.\*                   |
 | 0.30.\*       | 6.\*                   |
 | 0.29.\*       | 5.\*                   |

--- a/src/datadog_ids.rs
+++ b/src/datadog_ids.rs
@@ -1,6 +1,6 @@
-use opentelemetry::trace::{SpanId, TraceId};
-use tracing::Subscriber;
-use tracing_opentelemetry::OtelData;
+use opentelemetry::trace::{SpanId, TraceContextExt, TraceId};
+use tracing::{dispatcher::WeakDispatch, Subscriber};
+use tracing_opentelemetry::get_otel_context;
 use tracing_subscriber::{layer::Context, registry::LookupSpan};
 
 #[derive(serde::Serialize)]
@@ -38,16 +38,26 @@ impl From<SpanId> for DatadogSpanId {
     }
 }
 
-pub fn read_from_context<S>(ctx: &Context<'_, S>) -> Option<(DatadogTraceId, DatadogSpanId)>
+pub fn read_from_context<S>(
+    ctx: &Context<'_, S>,
+    weak_dispatch: Option<&WeakDispatch>,
+) -> Option<(DatadogTraceId, DatadogSpanId)>
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
-    ctx.lookup_current().and_then(|span_ref| {
-        span_ref.extensions().get::<OtelData>().map(|otel| {
-            let trace_id = otel.trace_id().unwrap_or(TraceId::INVALID);
-            let span_id = otel.span_id().unwrap_or(SpanId::INVALID);
+    let span_ref = ctx.lookup_current()?;
+    let dispatch = weak_dispatch?.upgrade()?;
 
-            (trace_id.into(), span_id.into())
-        })
-    })
+    let otel_cx = get_otel_context(&span_ref.id(), &dispatch)?;
+    let otel_span = otel_cx.span();
+    let span_context = otel_span.span_context();
+
+    let trace_id = span_context.trace_id();
+    let span_id = span_context.span_id();
+
+    if trace_id == TraceId::INVALID && span_id == SpanId::INVALID {
+        return None;
+    }
+
+    Some((trace_id.into(), span_id.into()))
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -5,7 +5,8 @@ use crate::{
     formatting::DatadogLog,
 };
 use chrono::Utc;
-use tracing::{span::Attributes, Event, Id, Subscriber};
+use std::sync::{Arc, OnceLock};
+use tracing::{dispatcher::WeakDispatch, span::Attributes, Dispatch, Event, Id, Subscriber};
 use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
 
 /// The layer responsible for formatting tracing events in a way datadog can parse them
@@ -13,6 +14,9 @@ use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
 #[derive(Debug, Clone)]
 pub struct DatadogFormattingLayer<Sink: EventSink + 'static> {
     event_sink: Sink,
+    // Captured during `on_register_dispatch` so that `on_event` can ask the OTel
+    // layer for the active OpenTelemetry context via `get_otel_context`.
+    dispatch: Arc<OnceLock<WeakDispatch>>,
 }
 
 impl<S: EventSink + 'static> DatadogFormattingLayer<S> {
@@ -25,8 +29,11 @@ impl<S: EventSink + 'static> DatadogFormattingLayer<S> {
     /// let layer: DatadogFormattingLayer<StdoutSink> =
     ///     DatadogFormattingLayer::with_sink(StdoutSink::default());
     /// ```
-    pub const fn with_sink(sink: S) -> Self {
-        Self { event_sink: sink }
+    pub fn with_sink(sink: S) -> Self {
+        Self {
+            event_sink: sink,
+            dispatch: Arc::new(OnceLock::new()),
+        }
     }
 }
 
@@ -39,6 +46,13 @@ impl Default for DatadogFormattingLayer<StdoutSink> {
 impl<S: Subscriber + for<'a> LookupSpan<'a>, Sink: EventSink + 'static> Layer<S>
     for DatadogFormattingLayer<Sink>
 {
+    fn on_register_dispatch(&self, subscriber: &Dispatch) {
+        // `on_register_dispatch` can fire more than once for a given subscriber if
+        // the layer is reused; subsequent `set` calls return Err and are ignored.
+        #[allow(clippy::let_underscore_must_use, clippy::let_underscore_untyped)]
+        let _ = self.dispatch.set(subscriber.downgrade());
+    }
+
     fn on_new_span(&self, span_attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         #[allow(clippy::expect_used)]
         let span = ctx.span(id).expect("Span not found, this is a bug");
@@ -72,7 +86,7 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>, Sink: EventSink + 'static> Layer<S>
             .collect();
 
         // look for datadog trace- and span-id
-        let datadog_ids = datadog_ids::read_from_context(&ctx);
+        let datadog_ids = datadog_ids::read_from_context(&ctx, self.dispatch.get());
 
         let log = DatadogLog {
             timestamp: Utc::now(),


### PR DESCRIPTION
Upgrades the OTel dependency stack to `opentelemetry 0.32` / `tracing-opentelemetry 0.33` and bumps the crate to 8.0.0 per the established "OTel minor = breaking" policy. 

There was a breaking change in `tracing-opentelemetry`, see https://github.com/tokio-rs/tracing-opentelemetry/releases/tag/v0.33.0 - I oriented myself after this example to see how they suggest it: https://github.com/tokio-rs/tracing-opentelemetry/blob/1d5422f1f37932fd65e434da618b305d4c94ee9c/examples/otel_context.rs